### PR TITLE
updated fraunhofer website url

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -91,7 +91,7 @@ contributor = [
     { name = "EZDRM", img = "contributor/ezdrm_logo_trademark.svg", href="https://ezdrm.com/"},
     { name = "Fastly", img = "contributor/fastly.svg", href="https://www.fastly.com/"},
     { name = "FRANCEtv", img = "contributor/France.tv_Logo.svg", href="https://www.francetvlab.fr/en" },
-    { name = "Fraunhofer", img = "contributor/Fraunhofer.png", href="https://fokus.fraunhofer.de/"},
+    { name = "Fraunhofer", img = "contributor/Fraunhofer.png", href="https://www.fokus.fraunhofer.de/"},
     { name = "Friends of Justin", img = "contributor/friends_of_justin-logo.png", href="https://friendsofjustin.knowbots.org"},
     { name = "Gearbrain", img = "contributor/Gearbrain_logo.jpg", href="https://www.gearbrain.com"},
     { name = "GiNi", img = "contributor/GiNi.Tech_Logo.svg", href="https://giniinc.tech"},


### PR DESCRIPTION
Link to Fraunhofer FOKUS website is not working. I have updated the fraunhofer website url from https://fokus.fraunhofer.de/ to https://www.fokus.fraunhofer.de/